### PR TITLE
Fix buddybuild

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -14,4 +14,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.dependency 'RSKImageCropper'
   s.dependency 'QBImagePickerController'
+  s.dependency 'React/Core'
 end

--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.homepage     = 'n/a'
   s.authors      = { "ivpusic" => "" }
-  s.source       = { :git => "https://github.com/ivpusic/react-native-image-crop-picker", :tag => 'v#{version}'}
+  s.source       = { :git => "https://github.com/tracemeinc/react-native-image-crop-picker", :tag => 'v0.20.0-traceme'}
   s.source_files = 'ios/src/*.{h,m}'
   s.platform     = :ios, "8.0"
   s.dependency 'RSKImageCropper'


### PR DESCRIPTION
Fix the .podspec on our fork of react-native-image-crop-picker so that it is in sync with the version specified in our package.json. This will allow us to fix buddybuild.

Also note that the referenced tag does not exist yet -- after I merge this, I will set the tag to the merge commit.